### PR TITLE
Added version-dependent parsing for md5status

### DIFF
--- a/atdlib.py
+++ b/atdlib.py
@@ -332,7 +332,7 @@ class atdsession:
 		prep = req.prepare()
 		resp = self._reqsend(prep, self._atdhost)
 
-		count = int( self._parse(resp.text, lambda x: int(x['totalCount'])) )
+		count = self._parse(resp.text, lambda x: int(x['totalCount']))
 
 		if count > 0:
 			log = self._parse(resp.text, lambda x: x['results'])


### PR DESCRIPTION
Fixes #7 
Issue resolution confirmed for ATD version 3.8.0.29.58939.
Need to verify md5status method still works for ATD versions 3.6.x and/or below.

Added LooseVersion import for version string comparison.
Added private attribute _atdver to store exact ATD software version upon connection.
Added conditional parsing of _md5log output depending on ATD version.
